### PR TITLE
chore: update bun.lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "bermuda-bay-bin",
       "dependencies": {
-        "@bermuda/sdk": "git+ssh://git@github.com:BermudaBay/sdk.git#bin-fixes",
+        "@bermuda/sdk": "git+ssh://git@github.com:BermudaBay/sdk.git#fix-bin",
         "@noble/hashes": "2.0.1",
         "ethers": "6.14.4",
       },
@@ -27,7 +27,7 @@
 
     "@aztec/bb.js": ["@aztec/bb.js@0.87.6", "", { "dependencies": { "comlink": "^4.4.1", "commander": "^12.1.0", "idb-keyval": "^6.2.1", "msgpackr": "^1.11.2", "pako": "^2.1.0", "pino": "^9.5.0", "tslib": "^2.4.0" }, "bin": { "bb.js": "dest/node/main.js" } }, "sha512-BLSZ6ptoIhrF0iaVpOTr5Cjgek38Y4d2Fo4+KMGBi4uK5jgLwWwxg7DV18n5Z4AUCNwPypJS8IMjbuh0zuqVhw=="],
 
-    "@bermuda/sdk": ["bermuda-bay-sdk@git+ssh://git@github.com:BermudaBay/sdk.git#6ae068723a1c7f20eaa69961c7620daa28868265", { "dependencies": { "@aztec/bb.js": "0.87.6", "@noble/curves": "1.9.0", "@noble/hashes": "2.0.1", "@noir-lang/noir_js": "1.0.0-beta.9", "@scopelift/stealth-address-sdk": "1.0.0-beta.2", "@stablelib/x25519": "2.0.1", "@stablelib/xchacha20poly1305": "2.0.1", "create-require": "1.1.1", "ethers": "6.14.4" } }, "6ae068723a1c7f20eaa69961c7620daa28868265"],
+    "@bermuda/sdk": ["bermuda-bay-sdk@git+ssh://git@github.com:BermudaBay/sdk.git#89c16ac5f16d3c178c350bef953ae890adc1b7dc", { "dependencies": { "@aztec/bb.js": "0.87.6", "@noble/curves": "1.9.0", "@noble/hashes": "2.0.1", "@noir-lang/noir_js": "1.0.0-beta.9", "@scopelift/stealth-address-sdk": "1.0.0-beta.2", "@stablelib/x25519": "2.0.1", "@stablelib/xchacha20poly1305": "2.0.1", "create-require": "1.1.1", "ethers": "6.14.4" } }, "89c16ac5f16d3c178c350bef953ae890adc1b7dc"],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 


### PR DESCRIPTION
Updates the `bun.lock` file so the most recent SDK commits from the `fix-bin` branch are used.