### PR TITLE
chore: update sdk

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
 
     "@aztec/bb.js": ["@aztec/bb.js@0.87.6", "", { "dependencies": { "comlink": "^4.4.1", "commander": "^12.1.0", "idb-keyval": "^6.2.1", "msgpackr": "^1.11.2", "pako": "^2.1.0", "pino": "^9.5.0", "tslib": "^2.4.0" }, "bin": { "bb.js": "dest/node/main.js" } }, "sha512-BLSZ6ptoIhrF0iaVpOTr5Cjgek38Y4d2Fo4+KMGBi4uK5jgLwWwxg7DV18n5Z4AUCNwPypJS8IMjbuh0zuqVhw=="],
 
-    "@bermuda/sdk": ["bermuda-bay-sdk@git+ssh://git@github.com:BermudaBay/sdk.git#2a1395fc229122b1d1b56a18d11eab2d99dee148", { "dependencies": { "@aztec/bb.js": "0.87.6", "@noble/curves": "1.9.0", "@noble/hashes": "2.0.1", "@noir-lang/noir_js": "1.0.0-beta.9", "@scopelift/stealth-address-sdk": "1.0.0-beta.2", "@stablelib/x25519": "2.0.1", "@stablelib/xchacha20poly1305": "2.0.1", "create-require": "1.1.1", "ethers": "6.14.4" } }, "2a1395fc229122b1d1b56a18d11eab2d99dee148"],
+    "@bermuda/sdk": ["bermuda-bay-sdk@git+ssh://git@github.com:BermudaBay/sdk.git#8908e49142d242374cd3367e53b9727d7293edbb", { "dependencies": { "@aztec/bb.js": "0.87.6", "@noble/curves": "1.9.0", "@noble/hashes": "2.0.1", "@noir-lang/noir_js": "1.0.0-beta.9", "@scopelift/stealth-address-sdk": "1.0.0-beta.2", "@stablelib/x25519": "2.0.1", "@stablelib/xchacha20poly1305": "2.0.1", "create-require": "1.1.1", "ethers": "6.14.4" } }, "8908e49142d242374cd3367e53b9727d7293edbb"],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 


### PR DESCRIPTION
Simple PR which updates the SDK dependency which now features the new caching abstraction that integrates with our [`chain-state`](https://github.com/BermudaBay/chain-state) repository.